### PR TITLE
[UI] 홈페이지 진행중인 프로젝트 sidebar 구현

### DIFF
--- a/src/features/home/ui/ChartSidebar.stories.tsx
+++ b/src/features/home/ui/ChartSidebar.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { ChartSidebar } from './ChartSidebar';
+
+const meta: Meta<typeof ChartSidebar> = {
+  title: 'component/home/ChartButton',
+  component: ChartSidebar,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChartSidebar>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/src/features/home/ui/ChartSidebar.stories.tsx
+++ b/src/features/home/ui/ChartSidebar.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { ChartSidebar } from './ChartSidebar';
 
 const meta: Meta<typeof ChartSidebar> = {
-  title: 'component/home/ChartButton',
+  title: 'component/feature/ChartButton',
   component: ChartSidebar,
   parameters: {
     layout: 'centered',

--- a/src/features/home/ui/ChartSidebar.style.ts
+++ b/src/features/home/ui/ChartSidebar.style.ts
@@ -12,7 +12,7 @@ export const SidebarButton = styled.button<{ isActive: boolean }>`
   background-color: ${({ theme }) => theme.color.WHITE};
   color: ${({ isActive }) =>
     isActive ? ({ theme }) => theme.color.BLACK_100 : ({ theme }) => theme.color.GRAY_50};
-  ${typo.SUBTITLE_20};
+  ${({ theme }) => theme.typo.SUBTITLE_20};
   text-align: left;
   padding-left: 2.4rem;
   cursor: pointer;

--- a/src/features/home/ui/ChartSidebar.style.ts
+++ b/src/features/home/ui/ChartSidebar.style.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import { typo } from '@/app/styles';
+
+export const SidebarContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SidebarButton = styled.button<{ isActive: boolean }>`
+  width: 26.4rem;
+  height: 6.8rem;
+  background-color: ${({ theme }) => theme.color.WHITE};
+  color: ${({ isActive }) =>
+    isActive ? ({ theme }) => theme.color.BLACK_100 : ({ theme }) => theme.color.GRAY_50};
+  ${typo.SUBTITLE_20};
+  text-align: left;
+  padding-left: 2.4rem;
+  cursor: pointer;
+
+  &:hover {
+    color: ${({ theme }) => theme.color.BLACK_100};
+  }
+
+  &:focus {
+    color: ${({ theme }) => theme.color.BLACK_100};
+    outline: none;
+  }
+`;
+
+export const RecentStackButton = styled(SidebarButton)`
+  border: 0.1rem solid ${({ theme }) => theme.color.GRAY_30};
+  border-radius: 1.6rem 1.6rem 0 0;
+`;
+
+export const TotalApplicationsButton = styled(SidebarButton)<{ isActive: boolean }>`
+  border: 0rem solid ${({ theme }) => theme.color.GRAY_30};
+  border-width: 0 0.1rem 0.1rem 0.1rem;
+  border-radius: 0 0 1.6rem 1.6rem;
+`;

--- a/src/features/home/ui/ChartSidebar.tsx
+++ b/src/features/home/ui/ChartSidebar.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import { RecentStackButton, SidebarContainer, TotalApplicationsButton } from './ChartSidebar.style';
+
+export const ChartSidebar = () => {
+  const [isActive, setIsActive] = useState(true);
+
+  const handleClick = (buttonName: 'stack' | 'apply'): void => {
+    setIsActive(buttonName === 'stack');
+  };
+
+  return (
+    <SidebarContainer>
+      <RecentStackButton autoFocus onClick={() => handleClick('stack')} isActive={isActive}>
+        최근 인기 스택
+      </RecentStackButton>
+      <TotalApplicationsButton onClick={() => handleClick('apply')} isActive={!isActive}>
+        누적 지원 횟수
+      </TotalApplicationsButton>
+    </SidebarContainer>
+  );
+};


### PR DESCRIPTION
## 반영 브랜치
- ui/home-sidebar/95 -> dev

## 📌 작업내용
- [x] sidebar ui 구현
- [x] 스토리북 작성

## 📸 상세한 설명 (사진은 선택)
<img width="732" alt="스크린샷 2024-10-16 오후 6 25 51" src="https://github.com/user-attachments/assets/5cf5d647-386a-4687-ab10-ba56232c990a">

- 상단 이미지의 왼쪽 sidebar를 구현했습니다.

### 1️⃣ focus style
- 기본적으로 `최근 인기 스택`에 autoFocus를 주었습니다. 
- 또한 hover와 focus는 아래와 같이 스타일을 설정해주었습니다.

  - 특별히 focus를 하면 outline이 기본적으로 설정되기 때문에 이를 none으로 설정해주었습니다.
  ```typescript
  &:hover {
    color: ${({ theme }) => theme.color.BLACK_100};
  }

  &:focus {
    color: ${({ theme }) => theme.color.BLACK_100};
    outline: none;
  }
  ```
### 2️⃣ focus 해제되는 문제 해결
#### 문제
- 버튼의 바깥부분을 클릭하면 focus가 해제되는 문제가 있었습니다.
- 따라서 버튼 외부를 클릭하더라도 폰트의 색을 유지시키도록 구현했습니다.

#### 해결방법
- 먼저 ChartSidebar.tsx에서 isActive라는 state를 정의해주고, 아래와 같이 저장해주었습니다.
  - 최근 인기 스택을 클릭 ->  isActive true
  - 누적 지원 횟수를 클릭 ->  isActive false 
  
  ```typescript
  const [isActive, setIsActive] = useState(true);

  const handleClick = (buttonName: 'stack' | 'apply'): void => {
    setIsActive(buttonName === 'stack');
  };

  ...
  <RecentStackButton autoFocus onClick={() => handleClick('stack')} isActive={isActive}>
        최근 인기 스택
      </RecentStackButton>
      <TotalApplicationsButton onClick={() => handleClick('apply')} isActive={!isActive}>
        누적 지원 횟수
  </TotalApplicationsButton>
  ```
  - 이를 위해 handleClick 함수에는 `stack`과 `apply`라는 문자열을 기준으로 true, false를 저장하도록 하였습니다.
- RecentStackButton과 TotalApplicationsButton은 SidebarButton을 extend하여 만들어진 컴포넌트입니다. 
- 따라서 SidebarButton에서 isActive라는 prop을 전달받고 isActive가 true일때 글자색 변동이 있도록 설정해주었습니다.
   ```typescript
   export const SidebarButton = styled.button<{ isActive: boolean }>`
    ...
    color: ${({ isActive }) =>
      isActive ? ({ theme }) => theme.color.BLACK_100 : ({ theme }) => theme.color.GRAY_50};
   ...
   ```
  -  isActive가 true일때 글자색이 black으로 변하기 때문에 isActive값이 false인 누적 지원 횟수는 `isActive={!isActive}`로 prop을 보내주었습니다.

### 3️⃣ 스토리북 작성
- 스토리북 `component/feature/ChartButton`에서 결과 확인 가능합니다.

## ✨ PR Checklist
- [x] PR 제목 양식은 알맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 되었나요?
- [x] Reviewers, Labels 는 등록하였나요?
- [x] 불필요한 주석, 코드는 제거하였나요?

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
focus 유지하는 방법을 처음에는 useRef를 사용하여 버튼 컨테이너의 외부를 클릭할 때에도 박스 외부 클릭으로 인한 blur이벤트 감지시 ref.current.focus()를 통해 focus를 유지하도록 했습니다. 하지만 모든 외부영역을 커버하지 못할뿐더러 깜빡임현상이 일어나 위와 같은 방법을 적용하게되었습니다. 

useState를 이용한 현재 방법이 괜찮은 방법인지 알려주시면 감사하겠습니다! 더 나은 방법이 있다면 공유 부탁드립니다!!

## 🚩 후속 작업 (선택)

## ✅ 리뷰어 유의사항


closed #95 
