### PR TITLE
[UI] 곧 마감되는 프로젝트 카드 UI 구현

### DIFF
--- a/src/features/home/ui/ClosingProject.stories.tsx
+++ b/src/features/home/ui/ClosingProject.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ClosingProject from './ClosingProject';
+
+const meta: Meta<typeof ClosingProject> = {
+  title: 'component/features/ClosingProject',
+  component: ClosingProject,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: '테스트를 위한 프로젝트명',
+    positions: ['프론트엔드 개발자', '백엔드 개발자'],
+    dueDay: '1',
+  },
+};

--- a/src/features/home/ui/ClosingProject.style.ts
+++ b/src/features/home/ui/ClosingProject.style.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export const ProjectContainer = styled.div`
+  width: 26.4rem;
+  height: 19.2rem;
+  padding: 3.4rem 3.2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  border:
+    0.1rem,
+    solid ${({ theme }) => theme.color.GRAY_30};
+  border-radius: 0.8rem;
+  cursor: pointer;
+`;
+
+export const Title = styled.h2`
+  ${({ theme }) => theme.typo.SUBTITLE_14};
+  color: ${({ theme }) => theme.color.BLACK_100};
+  margin-bottom: 1.2rem;
+`;
+
+export const Position = styled.li`
+  ${({ theme }) => theme.typo.CAPTION_12};
+  color: ${({ theme }) => theme.color.BLACK_80};
+  list-style-type: disc;
+  list-style-position: inside;
+  padding-left: 0.5rem;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-top: 2rem;
+`;
+
+export const dueBox = styled.div`
+  background-color: ${({ theme }) => theme.color.BLUE_30};
+  ${({ theme }) => theme.typo.CAPTION_12};
+  color: ${({ theme }) => theme.color.PRIMARY_BLUE};
+  padding: 0.35rem 0.8rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.4rem;
+`;
+
+export const Button = styled.button`
+  width: 10.8rem;
+  height: 3.8rem;
+  background-color: ${({ theme }) => theme.color.PRIMARY_BLUE};
+  color: ${({ theme }) => theme.color.WHITE};
+  ${({ theme }) => theme.typo.BODY_SEMIBOLD}
+  border-radius: 0.8rem;
+  cursor: pointer;
+`;

--- a/src/features/home/ui/ClosingProject.style.ts
+++ b/src/features/home/ui/ClosingProject.style.ts
@@ -7,11 +7,13 @@ export const ProjectContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
-  border:
-    0.1rem,
-    solid ${({ theme }) => theme.color.GRAY_30};
+  border: 0.1rem solid ${({ theme }) => theme.color.GRAY_30};
   border-radius: 0.8rem;
   cursor: pointer;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.color.BLUE_50};
+  }
 `;
 
 export const Title = styled.h2`
@@ -54,4 +56,5 @@ export const Button = styled.button`
   ${({ theme }) => theme.typo.BODY_SEMIBOLD}
   border-radius: 0.8rem;
   cursor: pointer;
+  border: none;
 `;

--- a/src/features/home/ui/ClosingProject.style.ts
+++ b/src/features/home/ui/ClosingProject.style.ts
@@ -13,6 +13,7 @@ export const ProjectContainer = styled.div`
 
   &:hover {
     border-color: ${({ theme }) => theme.color.BLUE_50};
+    box-shadow: 0rem 0.2rem 1.6rem 0.2rem ${({ theme }) => theme.color.BLUE_50_25};
   }
 `;
 

--- a/src/features/home/ui/ClosingProject.tsx
+++ b/src/features/home/ui/ClosingProject.tsx
@@ -1,0 +1,26 @@
+import * as S from './ClosingProject.style';
+
+interface Props {
+  title: string;
+  positions: string[];
+  dueDay: string;
+}
+
+const ClosingProject = ({ title, positions, dueDay }: Props) => {
+  return (
+    <S.ProjectContainer>
+      <S.Title>{title}</S.Title>
+      <ul>
+        {positions.map((item) => (
+          <S.Position>{item}</S.Position>
+        ))}
+      </ul>
+      <S.ButtonContainer>
+        <S.dueBox>{`마감 ${dueDay}일 전`}</S.dueBox>
+        <S.Button>지원하기</S.Button>
+      </S.ButtonContainer>
+    </S.ProjectContainer>
+  );
+};
+
+export default ClosingProject;


### PR DESCRIPTION
## 반영 브랜치
- ui/home-card/102 -> dev

## 📌 작업내용
- [x] 홈페이지 곧 마감되는 프로젝트의 카드 구현
- [x] 스토리북 작성

## 📸 상세한 설명 (사진은 선택)
<img width="809" alt="스크린샷 2024-10-17 오전 8 00 28" src="https://github.com/user-attachments/assets/356f6d79-bebb-45ae-a73d-1926723c868c">
- 홈페이지에 존재하는 곧 마감하는 프로젝트의 카드를 구현했습니다.

## ✨ PR Checklist
- [x] PR 제목 양식은 알맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 되었나요?
- [x] Reviewers, Labels 는 등록하였나요?
- [x] 불필요한 주석, 코드는 제거하였나요?

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

- [ ] 버튼 클릭시 해당 board로 이동하도록 라우팅설정

## ✅ 리뷰어 유의사항

closed #102
